### PR TITLE
Pablo/add support for fifo queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,15 @@ Subsequently it triggers its execution by calling the `#perform_now` method.
      schedule: "0 23 * * *"
   ```
 
+## FIFO Queues
+
+FIFO (First-In-First-Out) queues are designed to enhance messaging between applications when the order of operations and
+events is critical, or where duplicates can't be tolerated. FIFO queues also provide exactly-once processing but have a
+limited number of transactions per second (TPS).
+
+In order to make it work, you'll need to specify both `message_deduplication_id` and `message_group_id` in your job's
+arguments when calling `perform_later` or `perform_now`. Both mentioned arguments are required and both are `String` objects.
+
 ## Optional configuration
 This gem is configurable in case your setup requires different settings than the defaults.
 The snippet below shows the various configurable settings and their defaults.

--- a/lib/active_elastic_job/version.rb
+++ b/lib/active_elastic_job/version.rb
@@ -2,7 +2,7 @@ module ActiveElasticJob
   module VERSION
     MAJOR = 2
     MINOR = 0
-    TINY  = 1
+    TINY  = 2
     PRE   = nil
 
     STRING = [MAJOR, MINOR, TINY, PRE].compact.join('.')

--- a/lib/active_job/queue_adapters/active_elastic_job_adapter.rb
+++ b/lib/active_job/queue_adapters/active_elastic_job_adapter.rb
@@ -134,11 +134,12 @@ module ActiveJob
             message_body: serialized_job,
             delay_seconds: calculate_delay(timestamp),
             message_attributes: build_message_attributes(serialized_job)
-          }.merge(fifo_required_params(serialized_job))
+          }
 
           if queue_name.split('.').last == 'fifo'
             args.merge(fifo_required_params(serialized_job))
           end
+          return args
         end
 
         def build_message_attributes(serialized_job)


### PR DESCRIPTION
I fixed an issue with the rspec that was failing, and removed the initial merge you had of fifo arguments with the build_message args as it seemed unnecessary in the case the queue wasn't fifo. Let me know if you have any issues.